### PR TITLE
Proposed fix for Issue #12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ erl_crash.dump
 londibot-*.tar
 
 .DS_Store
+
+# No Vim backup or swap files
+*~
+*.swp

--- a/lib/londibot/commands/command_runner.ex
+++ b/lib/londibot/commands/command_runner.ex
@@ -7,8 +7,8 @@ defmodule Londibot.Commands.CommandRunner do
 
   def execute(%Command{command: :status}) do
     message =
-      @tfl_service.lines()
-      |> @tfl_service.status()
+      @tfl_service.lines!()
+      |> @tfl_service.status!()
       |> to_status_message()
 
     {:ok, message}
@@ -16,8 +16,8 @@ defmodule Londibot.Commands.CommandRunner do
 
   def execute(%Command{command: :disruptions}) do
     message =
-      @tfl_service.lines()
-      |> @tfl_service.status()
+      @tfl_service.lines!()
+      |> @tfl_service.status!()
       |> @tfl_service.disruptions()
       |> to_disruption_message()
 

--- a/lib/londibot/notifications/disruption_worker.ex
+++ b/lib/londibot/notifications/disruption_worker.ex
@@ -41,10 +41,10 @@ defmodule Londibot.DisruptionWorker do
     {:noreply, state}
   end
 
-  defp send_all_notifications(), do: Enum.each(create_notifications(), &@notifier.send/1)
+  defp send_all_notifications(), do: Enum.each(create_notifications(), &@notifier.send!/1)
 
   def create_notifications() do
-    for %StatusChange{line: changed_line} = change <- StatusBroker.get_changes(),
+    for %StatusChange{line: changed_line} = change <- StatusBroker.get_changes!(),
         subscription <- @subscription_store.all(),
         Subscription.subscribed?(subscription, changed_line) and not TFL.routinary?(change) do
       NotificationFactory.create(subscription, change)

--- a/lib/londibot/notifications/notifier.ex
+++ b/lib/londibot/notifications/notifier.ex
@@ -1,3 +1,3 @@
 defprotocol Londibot.Notifier do
-  def send(notification)
+  def send!(notification)
 end

--- a/lib/londibot/notifications/slack_notifier.ex
+++ b/lib/londibot/notifications/slack_notifier.ex
@@ -8,7 +8,7 @@ defimpl Londibot.Notifier, for: Londibot.SlackNotification do
   @endpoint "https://slack.com/api/chat.postMessage"
   @token Application.get_env(:londibot, :slack_token)
 
-  def send(%Notification{channel_id: channel_id, message: message}) do
+  def send!(%Notification{channel_id: channel_id, message: message}) do
     encoded_message = URI.encode(message)
     encoded_id = URI.encode(channel_id)
 
@@ -17,11 +17,11 @@ defimpl Londibot.Notifier, for: Londibot.SlackNotification do
     # Empty body -> message is in the URL
     case HTTPoison.post(url, "") do
       {:error, error} -> handle_error(error)
-      {:ok, response} -> handle_response(response)
+      {:ok, response} -> handle_response!(response)
     end
   end
 
-  defp handle_response(%Response{body: body} = resp) do
+  defp handle_response!(%Response{body: body} = resp) do
     case Poison.decode!(body) do
       %{"ok" => false, "error" => err} -> handle_error(resp, err)
       _ -> {:ok, resp}

--- a/lib/londibot/notifications/telegram_notifier.ex
+++ b/lib/londibot/notifications/telegram_notifier.ex
@@ -8,17 +8,17 @@ defimpl Londibot.Notifier, for: Londibot.TelegramNotification do
   @token Application.get_env(:londibot, :telegram_token)
   @endpoint "https://api.telegram.org/bot#{@token}/sendMessage"
 
-  def send(%Notification{channel_id: id, message: message}) do
+  def send!(%Notification{channel_id: id, message: message}) do
     headers = ["Content-Type": "Application/json"]
     body = Poison.encode!(%{chat_id: id, text: message, parse_mode: "markdown"})
 
     case HTTPoison.post(@endpoint, body, headers) do
       {:error, error} -> handle_error(error)
-      {:ok, response} -> handle_response(response)
+      {:ok, response} -> handle_response!(response)
     end
   end
 
-  defp handle_response(%Response{body: body} = resp) do
+  defp handle_response!(%Response{body: body} = resp) do
     case Poison.decode!(body) do
       %{"ok" => false, "description" => err} -> handle_error(resp, err)
       _ -> {:ok, resp}

--- a/lib/londibot/tfl/status_broker.ex
+++ b/lib/londibot/tfl/status_broker.ex
@@ -16,13 +16,13 @@ defmodule Londibot.StatusBroker do
   def start_link do
     Logger.info("Starting StatusBroker")
 
-    status = @tfl_service.lines() |> @tfl_service.status()
+    status = @tfl_service.lines!() |> @tfl_service.status!()
     Agent.start_link(fn -> status end, name: __MODULE__)
   end
 
-  def get_latest do
-    @tfl_service.lines()
-    |> @tfl_service.status()
+  def get_latest! do
+    @tfl_service.lines!()
+    |> @tfl_service.status!()
     |> cache()
   end
 
@@ -30,9 +30,9 @@ defmodule Londibot.StatusBroker do
     Agent.get(__MODULE__, & &1)
   end
 
-  def get_changes do
+  def get_changes! do
     cached = get_cached()
-    latest = get_latest()
+    latest = get_latest!()
 
     for {line2, old_status, _} <- cached,
         {line1, new_status, desc} <- latest,

--- a/lib/londibot/tfl/tfl.ex
+++ b/lib/londibot/tfl/tfl.ex
@@ -6,7 +6,7 @@ defmodule Londibot.TFL do
   @app_id Application.get_env(:londibot, :tfl_app_id)
   @app_key Application.get_env(:londibot, :tfl_app_key)
 
-  def lines do
+  def lines! do
     "https://api.tfl.gov.uk/Line/Mode/tube%2Cdlr%2Coverground%2Ctflrail"
     |> add_auth_params()
     |> HTTPoison.get!(recv_timeout: 50000)
@@ -15,13 +15,13 @@ defmodule Londibot.TFL do
     |> Enum.map(fn x -> x["id"] end)
   end
 
-  def status(lines) when is_list(lines) do
+  def status!(lines) when is_list(lines) do
     lines
     |> Enum.join("%2C")
-    |> status
+    |> status!
   end
 
-  def status(lines) when is_binary(lines) do
+  def status!(lines) when is_binary(lines) do
     "https://api.tfl.gov.uk/Line/#{lines}/Status"
     |> add_auth_params()
     |> HTTPoison.get!(recv_timeout: 50000)

--- a/lib/londibot/tfl/tfl_behaviour.ex
+++ b/lib/londibot/tfl/tfl_behaviour.ex
@@ -1,6 +1,6 @@
 defmodule Londibot.TFLBehaviour do
-  @callback lines() :: [String.t()]
-  @callback status(list) :: String.t()
-  @callback status(String.t()) :: String.t()
+  @callback lines!() :: [String.t()]
+  @callback status!(list) :: String.t()
+  @callback status!(String.t()) :: String.t()
   @callback disruptions(list) :: list
 end

--- a/lib/londibot/web/handlers/slack_handler.ex
+++ b/lib/londibot/web/handlers/slack_handler.ex
@@ -3,31 +3,31 @@ defmodule Londibot.Web.Handlers.SlackHandler do
   alias Londibot.Commands.CommandRunner
   alias Londibot.Web.CommandParser
 
-  def handle(%Plug.Conn{body_params: bp}), do: handle(bp)
+  def handle!(%Plug.Conn{body_params: bp}), do: handle!(bp)
 
   # Read: https://api.slack.com/slash-commands
   # Slack will occasionally send your command's request URL a simple POST
   # request to verify the server's SSL certificate. These requests will
   # include a parameter ssl_check set to 1 and a token parameter.
-  def handle(%{"ssl_check" => _, "token" => _}), do: "Received!"
+  def handle!(%{"ssl_check" => _, "token" => _}), do: "Received!"
 
   # TODO Potentially wrap execute in a task? and return a custom response?
-  def handle(%{"channel_id" => id, "text" => text}) do
+  def handle!(%{"channel_id" => id, "text" => text}) do
     with %Command{} = command <- CommandParser.parse(text) do
       command
       |> Command.with_channel_id(id)
       |> Command.with_service(:slack)
       |> CommandRunner.execute()
-      |> to_response()
+      |> to_response!()
     else
-      {:error, message} -> to_response({:error, message})
+      {:error, message} -> to_response!({:error, message})
     end
   end
 
   # If the user triggers an error, keep it silent and give only him the feedback.
-  defp to_response({:error, message}),
+  defp to_response!({:error, message}),
     do: Poison.encode!(%{text: message})
 
-  defp to_response({:ok, message}),
+  defp to_response!({:ok, message}),
     do: Poison.encode!(%{text: message, response_type: "in_channel"})
 end

--- a/lib/londibot/web/handlers/telegram_handler.ex
+++ b/lib/londibot/web/handlers/telegram_handler.ex
@@ -5,24 +5,24 @@ defmodule Londibot.Web.Handlers.TelegramHandler do
   alias Londibot.Commands.CommandRunner
   alias Londibot.Web.CommandParser
 
-  def handle(%Plug.Conn{body_params: bp}), do: handle(bp)
+  def handle!(%Plug.Conn{body_params: bp}), do: handle!(bp)
 
   # https://core.telegram.org/bots/api#update
-  def handle(%{"message" => %{"from" => %{"id" => id}, "text" => raw_text}}) do
+  def handle!(%{"message" => %{"from" => %{"id" => id}, "text" => raw_text}}) do
     with text <- remove_first_character(raw_text),
          %Command{} = command <- CommandParser.parse(text) do
       command
       |> Command.with_channel_id(id)
       |> Command.with_service(:telegram)
       |> CommandRunner.execute()
-      |> to_response(id)
+      |> to_response!(id)
     else
-      {:error, message} -> to_response({:error, message}, id)
+      {:error, message} -> to_response!({:error, message}, id)
     end
   end
 
   # Unless it's a text message, return empty body, a.k.a, ignore the message
-  def handle(unknown_message) do
+  def handle!(unknown_message) do
     Util.track_error(unknown_message,
       severity: :warn,
       message: "Unknown message received via Telegram"
@@ -34,7 +34,7 @@ defmodule Londibot.Web.Handlers.TelegramHandler do
   # Telegram commmands, unlike Slack, come with the leading slash.
   defp remove_first_character(str), do: String.slice(str, 1..-1)
 
-  defp to_response({_, message}, id) do
+  defp to_response!({_, message}, id) do
     %{method: "sendMessage", chat_id: id, text: message, parse_mode: "markdown"}
     |> Poison.encode!()
   end

--- a/lib/londibot/web/router.ex
+++ b/lib/londibot/web/router.ex
@@ -20,12 +20,12 @@ defmodule Londibot.Web.Router do
   get("/", do: send_resp(conn, 200, "Service up and running!!"))
 
   post "/slack" do
-    msg = SlackHandler.handle(conn)
+    msg = SlackHandler.handle!(conn)
     send_resp(conn, 200, msg)
   end
 
   post "/telegram" do
-    msg = TelegramHandler.handle(conn)
+    msg = TelegramHandler.handle!(conn)
     send_resp(conn, 200, msg)
   end
 

--- a/test/lib/world.ex
+++ b/test/lib/world.ex
@@ -73,7 +73,7 @@ defmodule World do
 
   def setup_notifier(expected_notifications) do
     Application.get_env(:londibot, :notifier)
-    |> expect(:send, expected_notifications, fn x -> x end)
+    |> expect(:send!, expected_notifications, fn x -> x end)
   end
 
   defp setup_subscription_store(subscriptions) do
@@ -93,12 +93,12 @@ defmodule World do
     end
 
     set_statuses_expectations = fn nth_execution ->
-      expect(tfl_service, :status, fn _ ->
+      expect(tfl_service, :status!, fn _ ->
         get_statuses_with_disruptions(@lines, disruptions, nth_execution)
       end)
     end
 
-    expect(tfl_service, :lines, @expected_executions, fn -> @lines end)
+    expect(tfl_service, :lines!, @expected_executions, fn -> @lines end)
     Enum.each(0..@expected_executions, set_statuses_expectations)
     Enum.each(0..@expected_executions, set_disruptions_expectations)
   end

--- a/test/lib/world_test.exs
+++ b/test/lib/world_test.exs
@@ -104,10 +104,10 @@ defmodule WorldTest do
     |> World.create()
 
     tfl_service = Application.get_env(:londibot, :tfl_service)
-    lines = tfl_service.lines()
+    lines = tfl_service.lines!()
     assert length(lines) == 15
 
-    statuses = tfl_service.status(lines)
+    statuses = tfl_service.status!(lines)
 
     assert Enum.member?(statuses, {"victoria", "Minor delays", "because..."})
     assert Enum.member?(statuses, {"circle", "Line closed", "boom!"})
@@ -147,8 +147,8 @@ defmodule WorldTest do
            ]
 
     tfl_service = Application.get_env(:londibot, :tfl_service)
-    lines = tfl_service.lines()
-    statuses = tfl_service.status(lines)
+    lines = tfl_service.lines!()
+    statuses = tfl_service.status!(lines)
     disruptions = tfl_service.disruptions(statuses)
 
     assert disruptions == [
@@ -236,7 +236,7 @@ defmodule WorldTest do
              {"victoria", "Good Service", ""},
              {"tfl rail", "Good Service", ""},
              {"tram", "Good Service", ""}
-           ] == service.status(nil)
+           ] == service.status!(nil)
 
     assert [
              {"circle", "Severe Delays", "oops"},
@@ -254,7 +254,7 @@ defmodule WorldTest do
              {"victoria", "Good Service", ""},
              {"tfl rail", "Good Service", ""},
              {"tram", "Good Service", ""}
-           ] == service.status(nil)
+           ] == service.status!(nil)
 
     assert [
              {"circle", "Good Service", ""},
@@ -272,7 +272,7 @@ defmodule WorldTest do
              {"victoria", "Good Service", ""},
              {"tfl rail", "Good Service", ""},
              {"tram", "Good Service", ""}
-           ] == service.status(nil)
+           ] == service.status!(nil)
 
     assert [
              {"circle", "Good Service", ""},
@@ -290,7 +290,7 @@ defmodule WorldTest do
              {"victoria", "Good Service", ""},
              {"tfl rail", "Good Service", ""},
              {"tram", "Good Service", ""}
-           ] == service.status(nil)
+           ] == service.status!(nil)
 
     assert [
              {"circle", "Good Service", ""},
@@ -308,6 +308,6 @@ defmodule WorldTest do
              {"victoria", "Shut down", "oops"},
              {"tfl rail", "Good Service", ""},
              {"tram", "Good Service", ""}
-           ] == service.status(nil)
+           ] == service.status!(nil)
   end
 end

--- a/test/londibot/tfl/status_broker_test.exs
+++ b/test/londibot/tfl/status_broker_test.exs
@@ -18,7 +18,7 @@ defmodule Londibot.StatusBrokerTest do
     |> World.create()
 
     StatusBroker.start_link([])
-    status = StatusBroker.get_latest()
+    status = StatusBroker.get_latest!()
 
     assert status == [
              {"circle", "Severe Delays", "Description about delays"},
@@ -89,7 +89,7 @@ defmodule Londibot.StatusBrokerTest do
     |> World.create()
 
     StatusBroker.start_link([])
-    diff = StatusBroker.get_changes()
+    diff = StatusBroker.get_changes!()
 
     assert [
              %StatusChange{

--- a/test/londibot/tfl/tfl_test.exs
+++ b/test/londibot/tfl/tfl_test.exs
@@ -5,12 +5,12 @@ defmodule Londibot.TFLTest do
 
   @tag :callout
   test "lists all the lines of tube, dlr, overground and tfl-rail" do
-    assert length(TFL.lines()) == 14
+    assert length(TFL.lines!()) == 14
   end
 
   @tag :callout
   test "fetches the status of a single line" do
-    [{name, status, description}] = TFL.status("victoria")
+    [{name, status, description}] = TFL.status!("victoria")
 
     assert name == "Victoria"
     assert String.length(status) != 0
@@ -19,7 +19,7 @@ defmodule Londibot.TFLTest do
 
   @tag :callout
   test "fetches the status of multiple lines" do
-    [{name, status, _}, {name2, status2, _}] = TFL.status(["victoria", "circle"])
+    [{name, status, _}, {name2, status2, _}] = TFL.status!(["victoria", "circle"])
 
     assert name == "Circle"
     assert name2 == "Victoria"

--- a/test/londibot/web/handlers/slack_handler_test.exs
+++ b/test/londibot/web/handlers/slack_handler_test.exs
@@ -6,7 +6,7 @@ defmodule Londibot.Web.Handlers.SlackHandlerTest do
   test "handles SSL checks" do
     ssl_check_request = %{"ssl_check" => "???", "token" => "some-token"}
 
-    assert "Received!" == SlackHandler.handle(ssl_check_request)
+    assert "Received!" == SlackHandler.handle!(ssl_check_request)
   end
 
   test "status request returns all the statuses" do
@@ -14,7 +14,7 @@ defmodule Londibot.Web.Handlers.SlackHandlerTest do
     |> World.with_disruption(line: "victoria", status: "Severe Delays", description: "oops")
     |> World.create()
 
-    response = SlackHandler.handle(%{"channel_id" => "123", "text" => "status"})
+    response = SlackHandler.handle!(%{"channel_id" => "123", "text" => "status"})
 
     assert response == """
            {\"text\":\"\
@@ -46,13 +46,13 @@ defmodule Londibot.Web.Handlers.SlackHandlerTest do
     )
     |> World.create()
 
-    response = SlackHandler.handle(%{"channel_id" => "123", "text" => "disruptions"})
+    response = SlackHandler.handle!(%{"channel_id" => "123", "text" => "disruptions"})
 
     assert response == "{\"text\":\"BAKERLOO LINE: oops\\n\",\"response_type\":\"in_channel\"}"
   end
 
   test "an ephemeral response is sent if the command doesn't exist" do
-    response = SlackHandler.handle(%{"channel_id" => "123", "text" => "break pls!"})
+    response = SlackHandler.handle!(%{"channel_id" => "123", "text" => "break pls!"})
 
     assert response == "{\"text\":\"The command you just tried doesn't exist!\"}"
   end

--- a/test/londibot/web/handlers/telegram_handler_test.exs
+++ b/test/londibot/web/handlers/telegram_handler_test.exs
@@ -9,7 +9,7 @@ defmodule Londibot.Web.Handlers.TelegramHandlerTest do
     |> World.create()
 
     response =
-      TelegramHandler.handle(%{"message" => %{"from" => %{"id" => "123"}, "text" => "/status"}})
+      TelegramHandler.handle!(%{"message" => %{"from" => %{"id" => "123"}, "text" => "/status"}})
 
     assert response == """
            {\"text\":\"\
@@ -42,7 +42,7 @@ defmodule Londibot.Web.Handlers.TelegramHandlerTest do
     |> World.create()
 
     response =
-      TelegramHandler.handle(%{
+      TelegramHandler.handle!(%{
         "message" => %{"from" => %{"id" => "123"}, "text" => "/disruptions"}
       })
 
@@ -56,7 +56,9 @@ defmodule Londibot.Web.Handlers.TelegramHandlerTest do
 
   test "an error response is sent if the command doesn't exist" do
     response =
-      TelegramHandler.handle(%{"message" => %{"from" => %{"id" => "123"}, "text" => "break pls!"}})
+      TelegramHandler.handle!(%{
+        "message" => %{"from" => %{"id" => "123"}, "text" => "break pls!"}
+      })
 
     assert response == """
            {\"text\":\"The command you just tried doesn't exist!\",\
@@ -67,6 +69,6 @@ defmodule Londibot.Web.Handlers.TelegramHandlerTest do
   end
 
   test "Upon unknown body params, ignore the message" do
-    assert "" == TelegramHandler.handle(%{"channel_id" => "123", "text" => "break pls!"})
+    assert "" == TelegramHandler.handle!(%{"channel_id" => "123", "text" => "break pls!"})
   end
 end


### PR DESCRIPTION
Proposed fix for Issue #12 

**In lib/londibot/notifications:**	
-  lib/londibot/notifications/notifier.ex
Changed the protocol function `Londibot.Notifier.send/1` to `send!`
since all the implementation versions call a private function which
calls `Posion.decode!\1` 
-  lib/londibot/notifications/slack_notifier.ex
-  lib/londibot/notifications/telegram_notifier.ex
 	Changed the implementation versions of `send/1` and
 	`handle_response\1` to `send!/1` and `handle_response!\1`,
 	respectively.
-  lib/londibot/notifications/disruption_worker.ex
Changed calls to `send/1` to `send!/1`

**In lib/londibot/tfl:**
- lib/londibot/tfl_behaviour.ex
	Changed the `lines/0` and both `status/1` callbacks to `lines!/0`
 	and `status!/1`, respectively. 
- lib/londibot/tfl.ex
	Changed the implementation versions of the above.
- lib/londibot/status_broker.ex
	Updated calls for `lines/0` and `status/1` to `lines!/0` and
	`status!/1` respectively.  This required updating `get_changes/0` to
	`get_changes!/0` and `get_latest/0` to `get_latest!/0`.  Despite a
	call to `Londibot.TFL.lines!\0`,	`Londibot.StatusBroker.start_link/0`
        was not changed.

**In lib/londibot/web/handlers:**
- lib/londibot/web/handlers/slack_handler.ex
- lib/londibot/web/handlers/telegram_handler.ex
 	Private functions `to_response/1` calls `Poison.encode!\1` and have
 	been changed to `to_response!/1` which required changing `handle/1`
 	functions to `handle!/1`

**In lib/londibot/web:**	
- lib/londibot/web/router.ex
 	Handler's `handle/1` functions changed to `handle!/1` 

**In lib/londibot/commands:**
- lib/londibot/commands/command_runner.ex
 	The `lines/0` and `status/1` calls changed to `lines!/0` and
 	`status!/1`.

**_All tests pass_**